### PR TITLE
Auth validation: Check hash instead of size

### DIFF
--- a/routes/PutUpload.js
+++ b/routes/PutUpload.js
@@ -107,7 +107,7 @@ export default async (req, res) => {
 			throw { code: 500 };
 		}
 
-		// Check for indicated constraints
+		// Check for indicated hash constraint
 		for (let tag of req.blossom.auth.tags) {
 			if (tag[0] === 'x') {
 				if (expectedHash) {
@@ -118,7 +118,14 @@ export default async (req, res) => {
 			}
 		}
 
-		if (expectedHash !== undefined && expectedHash !== hash) {
+		if (expectedHash == undefined) {
+			throw {
+				code: 401,
+				message: 'A x tag with a content hash is required in the auth header',
+			};
+		}
+			
+		if (expectedHash !== hash) {
 			throw {
 				code: 401,
 				message: 'Hash given in x tag does not match detected content hash',

--- a/routes/PutUpload.js
+++ b/routes/PutUpload.js
@@ -120,7 +120,7 @@ export default async (req, res) => {
 
 		const stat = fs.statSync(tempPath);
 
-		if (stat.size !== constrainSize) {
+		if (constrainSize !== undefined && stat.size !== constrainSize) {
 			throw {
 				code: 401,
 				message: 'Value given in size tag does not match detected size',

--- a/routes/PutUpload.js
+++ b/routes/PutUpload.js
@@ -41,7 +41,7 @@ const ComputeTorrentInfo = (input, options = {}) => {
 };
 
 export default async (req, res) => {
-	let client, tempName, tempPath, constrainSize;
+	let client, tempName, tempPath, expectedHash;
 
 	try {
 		if (req.blossom.verb !== 'upload') {
@@ -109,21 +109,19 @@ export default async (req, res) => {
 
 		// Check for indicated constraints
 		for (let tag of req.blossom.auth.tags) {
-			if (tag[0] === 'size') {
-				if (constrainSize) {
-					throw { code: 401, message: 'Duplicate size tag' };
+			if (tag[0] === 'x') {
+				if (expectedHash) {
+					throw { code: 401, message: 'Duplicate x tag' };
 				}
 
-				constrainSize = parseInt(tag[1]);
+				expectedHash = tag[1];
 			}
 		}
 
-		const stat = fs.statSync(tempPath);
-
-		if (constrainSize !== undefined && stat.size !== constrainSize) {
+		if (expectedHash !== undefined && expectedHash !== hash) {
 			throw {
 				code: 401,
-				message: 'Value given in size tag does not match detected size',
+				message: 'Hash given in x tag does not match detected content hash',
 			};
 		}
 


### PR DESCRIPTION
The latest blossom spec does not use the `size` attribute for auth validation anymore. Instead the the `x` attribute is used to validate the hash.

https://github.com/hzrd149/blossom/blob/master/buds/02.md#upload-authorization-required

Currently the upload to `cdn.sattelite.earth` is broken with the latest version of the `blossom-client` package.

I changed the validation in `PutUpload.js` according to the spec:

- size is not used anymore
- the x tag with a hash is required
- the hash in the x tag must match the uploaded content
