### PR TITLE
Detect mime types and extensions from name tag and Content-Type header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express": "^4.18.3",
         "file-type": "^19.0.0",
         "magnet-uri": "^7.0.5",
-        "mime-types": "^2.1.35",
+        "mime": "^4.0.4",
         "morgan": "^1.10.0",
         "nostr-tools": "^1.17.0",
         "parse-torrent": "^11.0.16",
@@ -2481,14 +2481,18 @@
       }
     },
     "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
+      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {
@@ -2980,6 +2984,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/send/node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express": "^4.18.3",
     "file-type": "^19.0.0",
     "magnet-uri": "^7.0.5",
-    "mime-types": "^2.1.35",
+    "mime": "^4.0.4",
     "morgan": "^1.10.0",
     "nostr-tools": "^1.17.0",
     "parse-torrent": "^11.0.16",


### PR DESCRIPTION
It gets the extension from the optional [name tag](https://github.com/lovvtide/satellite-web/blob/master/docs/cdn.md), if present, and the mime type from Content-Type header [(BUD-2)](https://github.com/hzrd149/blossom/blob/4f650d799fc8c8ff3c13ea0daeff39a57c222c81/buds/02.md). If none of them is available, it tries to detect the mime type using the magic number from the buffer (which works only for binary-based formats). It tries to infer mime type or extension when one of them is not available and defaults to `application/octet-stream` when nothing works. Using `mime` package instead of `mime-types` because it was getting the extension wrong for `text/javascript` due to an outdated dependency.